### PR TITLE
Added Node Cluster

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: '3' 
+ 
+services: 
+  node1: 
+    build: ./nodejs 
+    ports: 
+      - "81:3000" 
+  node2: 
+    build: ./nodejs 
+    ports: 
+      - "82:3000" 
+  node3: 
+    build: ./nodejs 
+    ports: 
+      - "83:3000" 
+  nginx: 
+    build: ./nginx 
+    ports: 
+      - "80:80" 
+    depends_on:
+      - node1
+      - node2
+      - node3

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx 
+RUN rm /etc/nginx/conf.d/default.conf 
+COPY nginx.conf /etc/nginx/conf.d/default.conf 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,11 @@
+upstream nodeapp { 
+  server 172.17.0.1:81; 
+  server 172.17.0.1:82; 
+  server 172.17.0.1:83; 
+} 
+server { 
+  listen 80; 
+  location / { 
+  proxy_pass http://nodeapp; 
+  } 
+} 

--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine 
+RUN apk add --update nodejs npm 
+WORKDIR /usr/src/app 
+EXPOSE 3000 
+COPY src/ .
+RUN ls -la /usr/src/app/* 
+RUN npm install 
+CMD [ "node", "app.js" ]


### PR DESCRIPTION
nodejs\Dockerfile installs nodejs and npm within the directory usr/src/app on port 3000 and runs app.js when an instance of a container is built.

nginx/nginx.conf - distributes traffic to 127.17.0.1:81-83 and listens on port 80

nginx\Dockerfile pulls nginx image then removes the default configuration file from the image and replaces it with the custom one in nginx\nginx.conf

docker-compose.yaml - uses version 3 and lists each container which uses the node.js dockerfile and listens in ports 81-83:3000 and builds dockerfile from nginx folder which exposes port 80:80 which distributes traffic to the conatiners. This doesn't build till all nodes are built.