### PR TITLE
Added Configuration for RabbitMQ

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,26 +35,84 @@ services:
       - ./scripts:/scripts
     restart: "no"
     entrypoint: [ "bash", "/scripts/mongo_setup.sh"]
-  node1: 
-    build: ./nodejs 
+  node1:
+    build: ./nodejs
     container_name: "AppNode1"
-    ports: 
-      - "81:3000" 
-  node2: 
-    build: ./nodejs 
+    ports:
+    - "81:3000"
+  node2:
+    build: ./nodejs
     container_name: "AppNode2"
-    ports: 
-      - "82:3000" 
-  node3: 
-    build: ./nodejs 
+    ports:
+    - "82:3000"
+  node3:
+    build: ./nodejs
     container_name: "AppNode3"
-    ports: 
-      - "83:3000" 
-  nginx: 
-    build: ./nginx 
-    ports: 
-      - "80:80" 
+    ports:
+    - "83:3000"
+  nginx:
+    build: ./nginx
+    container_name: "NGINX"
+    ports:
+    - "80:80"
     depends_on:
-      - node1
-      - node2
-      - node3
+    - node1
+    - node2
+    - node3
+
+ # Message tier
+  rabbitmq-stats:
+    image: bitnami/rabbitmq:3.8.14
+    container_name: rabbitmq-stats
+    volumes:
+      - rabbitmq-stats-data:/bitnami
+    environment:
+      - RABBITMQ_NODE_TYPE=stats
+      - RABBITMQ_NODE_NAME=rabbitmq@rabbitmq-stats
+      - RABBITMQ_ERL_COOKIE=password
+    ports:
+      - "50001:15672"
+  rabbitmq-queue-one:
+    image: bitnami/rabbitmq:3.8.14
+    container_name: rabbitmq-queue-one
+    depends_on:
+      - rabbitmq-stats
+    volumes:
+      - rabbitmq-queue-one-data:/bitnami
+    environment:
+      - RABBITMQ_NODE_TYPE=queue-disc
+      - RABBITMQ_NODE_NAME=rabbitmq@rabbitmq-queue-one
+      - RABBITMQ_CLUSTER_NODE_NAME=rabbitmq@rabbitmq-stats
+      - RABBITMQ_ERL_COOKIE=password
+  rabbitmq-queue-two:
+    image: bitnami/rabbitmq:3.8.14
+    container_name: rabbitmq-queue-two
+    depends_on:
+      - rabbitmq-stats
+    volumes:
+      - rabbitmq-queue-two-data:/bitnami
+    environment:
+      - RABBITMQ_NODE_TYPE=queue-disc
+      - RABBITMQ_NODE_NAME=rabbitmq@rabbitmq-queue-two
+      - RABBITMQ_CLUSTER_NODE_NAME=rabbitmq@rabbitmq-stats
+      - RABBITMQ_ERL_COOKIE=password
+
+  haproxy: 
+    image: haproxy:1.7 
+    volumes: 
+      - ./rabbitmq/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro 
+    depends_on: 
+      - rabbitmq-stats 
+      - rabbitmq-queue-one
+      - rabbitmq-queue-two
+    ports: 
+      - 15672:15672
+      - 5672:5672
+      
+volumes:
+  rabbitmq-stats-data:
+    driver: local
+  rabbitmq-queue-one-data:
+    driver: local
+  rabbitmq-queue-two-data:
+    driver: local

--- a/rabbitmq/haproxy.cfg
+++ b/rabbitmq/haproxy.cfg
@@ -1,0 +1,44 @@
+global 
+        log 127.0.0.1   local1 
+        maxconn 4096 
+ 
+defaults 
+        log     global 
+        mode    tcp 
+        option  tcplog 
+        retries 3 
+        option redispatch
+        maxconn 2000 
+        timeout connect 5000 
+        timeout client 50000 
+        timeout server 50000 
+ 
+listen  stats 
+        bind *:1936 
+        mode http 
+        stats enable 
+        stats hide-version 
+        stats realm Haproxy\ Statistics 
+        stats uri / 
+ 
+listen rabbitmq 
+        bind *:5672 
+        mode            tcp 
+        balance         roundrobin 
+        timeout client  3h 
+        timeout server  3h 
+        option          clitcpka 
+        server          rabbitmq-stats rabbitmq-stats:5672  check inter 5s rise 2 fall 3 
+        server          rabbitmq-queue-one rabbitmq-queue-one:5672  check inter 5s rise 2 fall 3 
+        server          rabbitmq-queue-two rabbitmq-queue-two:5672  check inter 5s rise 2 fall 3 
+ 
+listen mgmt 
+        bind *:15672 
+        mode            tcp 
+        balance         roundrobin 
+        timeout client  3h 
+        timeout server  3h 
+        option          clitcpka 
+        server          rabbitmq-stats rabbitmq-stats:15672  check inter 5s rise 2 fall 3 
+        server          rabbitmq-queue-one rabbitmq-queue-one:15672  check inter 5s rise 2 fall 3 
+        server          rabbitmq-queue-two rabbitmq-queue-two:15672  check inter 5s rise 2 fall 3


### PR DESCRIPTION
docker-compose.yaml - Added changes for a three-node RabbitMQ cluster which exposes the ports of the message broker outside of the vm on port 15672

rabbitmq\haproxy.cfg - handles load balancing of inbound traffic to the three rabbitmq servers.